### PR TITLE
use the tempdir also for npm.load

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -62,7 +62,7 @@ describe("registry mocking - npm.install", function () {
 
   it("sends the module as tarball (version specified)", function (done) {
     mr(port, function (s) {
-      npm.load({registry: address}, function () {
+      npm.load({cache: tempdir, registry: address}, function () {
         npm.commands.install(tempdir, "underscore@1.3.1", function (err) {
           require.cache[path] = null
           var version = require(path).version
@@ -75,7 +75,7 @@ describe("registry mocking - npm.install", function () {
   })
   it("sends the module as tarball (no version specified -- latest)", function (done) {
     mr(port, function (s) {
-      npm.load({registry: address}, function () {
+      npm.load({cache: tempdir, registry: address}, function () {
         npm.commands.install(tempdir, "underscore", function (err) {
           require.cache[path] = null
           var version = require(path).version
@@ -88,7 +88,7 @@ describe("registry mocking - npm.install", function () {
   })
   it("i have a test package with one dependency", function (done) {
     mr(port, function (s) {
-      npm.load({registry: address}, function () {
+      npm.load({cache: tempdir, registry: address}, function () {
         npm.commands.install(tempdir, "test-package-with-one-dep", function (err) {
           var exists = fs.existsSync(tempdir + "/node_modules/test-package-with-one-dep/" +
             "node_modules/test-package/package.json")
@@ -118,7 +118,7 @@ describe("extending the predefined mocks with custom ones", function () {
         request(address + "/ente400", function (er, res) {
           assert.equal(res.body, JSON.stringify({ente400: "true"}))
           assert.equal(res.statusCode, 400)
-          npm.load({registry: address}, function () {
+          npm.load({cache: tempdir, registry: address}, function () {
             npm.commands.install(tempdir, "async@0.1.0", function (err) {
               var exists = fs.existsSync(tempdir + "/node_modules/async/package.json")
               assert.ok(exists)


### PR DESCRIPTION
Do not use the default npm cache for the tests.
