### PR TITLE
Apply replacement of the original registry also for custom mocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,17 @@ function start (options, cb) {
             .replyWithFile(status, target)
         })
 
+        function replaceRegistry (res) {
+          return JSON.stringify(res)
+                  .replace(/http:\/\/registry\.npmjs\.org/ig,
+                          'http://localhost:' + port)
+        }
+
         function next () {
           var res
           if (!customTarget) {
             res = require(__dirname + "/fixtures" + route)
-            res = JSON.stringify(res)
-              .replace(/http:\/\/registry\.npmjs\.org/ig,
-                      'http://localhost:' + port)
+            res = replaceRegistry(res)
 
             return hockServer[method](route)
               .many({max: maxReq, min: minReq})
@@ -67,6 +71,8 @@ function start (options, cb) {
           } catch (e) {
             res = customTarget
           }
+
+          res = replaceRegistry(res)
           hockServer[method](route)
             .many({max: maxReq, min: minReq})
             .reply(status, res)
@@ -80,7 +86,6 @@ function start (options, cb) {
 function extendRoutes (mocks) {
   for (var method in mocks) {
     predefinedMocks[method] = extend(predefinedMocks[method], mocks[method])
-
   }
   return predefinedMocks
 }

--- a/test/server.js
+++ b/test/server.js
@@ -138,6 +138,25 @@ describe("extending the predefined mocks with custom ones", function () {
       })
     })
   })
+  it("uses the fake registry (GH-22)", function (done) {
+      var customMocks = {
+        "get": {
+          "/async/-/async-0.1.0.tgz": [200, __dirname + "/fixtures/async/-/async-0.1.0.tgz"],
+          "/async/0.1.0": [200, __dirname + "/fixtures/async/0.1.0"],
+        }
+      }
+      mr({port: port, mocks: customMocks}, function (err, s) {
+        if (err) return done(err)
+        var client = new RC(conf)
+        client.get("/async/0.1.0", function (er, data, raw, res) {
+          assert.notEqual(data.dist.tarball,
+            "http://registry.npmjs.org/async/-/async-0.1.0.tgz")
+          assert.ok(/localhost/.test(data.dist.tarball))
+          s.close()
+          done(er)
+        })
+      })
+    })
   it("serves js-files", function (done) {
     var customMocks = {
       "get": {


### PR DESCRIPTION
I noticed that issue when I was running the tests, with my npm
cache cleaned and no network connection.
