### PR TITLE
Send connection-close

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function start (options, cb) {
     mocks = extendRoutes(mocks)
     plugin(hockServer)
 
+    hockServer.defaultReplyHeaders({ connection: 'close' })
     hockServer
       .filteringPath(function (p) {
         if (!hockServer.hasRoute("GET", p)) {

--- a/test/server.js
+++ b/test/server.js
@@ -121,6 +121,7 @@ describe("extending the predefined mocks with custom ones", function () {
     mr({port: port, mocks: customMocks}, function (err, s) {
       if (err) return done(err)
       request(address + "/ente200", function (er, res) {
+        assert.equal(res.headers.connection, 'close')
         assert.deepEqual(res.body, JSON.stringify({ente200: "true"}))
         assert.equal(res.statusCode, 200)
         request(address + "/ente400", function (er, res) {


### PR DESCRIPTION
This way, tests can pass on Node 0.11 and io.js