### PR TITLE
remove broken wildcard route for /missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installing underscore 1.3.1:
 ```javascript
 var mr = require("npm-registry-mock")
 
-mr({port: 1331}}, function (err, s) {
+mr({port: 1331}, function (err, s) {
   npm.load({registry: "http://localhost:1331"}, function () {
     npm.commands.install("/tmp", "underscore@1.3.1", function (err) {
       // assert npm behaves right...
@@ -90,9 +90,8 @@ $ ./add-fixture.sh my-weird-package 1.2.3
 
 to add that package to the fixtures directory.
 
-##Breaking Changes for 0.7
+##Breaking Changes for 1.0
  - the callback returns `err, server` now, instead of just server (https://github.com/npm/npm-registry-mock/issues/20)
  - options must be of type `object`
  - a "plugin" is injected via options.plugin, not as a mock being a function
  - a plugin does not override the default routes any more
- - throwOnUnmatched is not working any more

--- a/fixtures/missing.json
+++ b/fixtures/missing.json
@@ -1,1 +1,0 @@
-{"error": "version not found"}

--- a/index.js
+++ b/index.js
@@ -19,18 +19,6 @@ function start (options, cb) {
     mocks = extendRoutes(mocks)
     plugin(hockServer)
 
-    hockServer
-      .filteringPath(function (p) {
-        if (!hockServer.hasRoute("GET", p)) {
-          var splits = p.split('/').filter(function (part) {
-            return part !== ''
-          })
-          var name = splits[0]
-          return '/missing'
-        }
-        return p
-      })
-
     Object.keys(mocks).forEach(function (method) {
       Object.keys(mocks[method]).forEach(function (route) {
         var status = mocks[method][route][0]

--- a/lib/predefines.js
+++ b/lib/predefines.js
@@ -23,11 +23,9 @@ var routes = pkgs.map(function(p) {
 }, []).reduce(function(gets, route) {
   route = route.substr(fixtures.length)
   if (route) {
-    if (~route.indexOf('missing')) gets[route] = [404]
-    else gets[route] = [200]
+    gets[route] = [200]
   }
 
-  gets['/missing'] = [404]
   return gets
 }, {})
 

--- a/test/server.js
+++ b/test/server.js
@@ -293,49 +293,7 @@ describe("api", function () {
   })
 })
 
-
-describe('invalid version', function() {
-  var pkgs = fs.readdirSync(path.join(__dirname, '..', 'fixtures'))
-                .filter(function(fp) {
-                  return !/.json/.test(fp)
-                })
-  pkgs.forEach(function(pkg) {
-    describe(pkg, function() {
-      it('should return an error message saying version not found',
-        function(done) {
-        mr({port: port}, function (err, s) {
-          if (err) return done(err)
-          var client = new RC(conf)
-          client.get('/'+pkg+'/1.7.50', function(er, data, raw, res) {
-            assert.equal(data.error, 'version not found')
-            s.close()
-            done()
-          })
-        })
-      })
-    })
-  })
-})
-
 describe('multiple requests', function () {
-  it('will return missing after the first request, if specified', function (done) {
-    mr({
-      port: port,
-      minReq: 1,
-      maxReq: 1
-    },
-    function (err, s) {
-      if (err) return done(err)
-      var client = new RC(conf)
-      request(address + '/underscore/latest', function (er, res) {
-        request(address + '/underscore/latest', function (er, res) {
-          assert.equal(res.body, '{"error":"version not found"}')
-          s.close()
-          done()
-        })
-      })
-    })
-  })
   it('will not error after the first request, if nothing is specified', function (done) {
     mr({
       port: port


### PR DESCRIPTION
remove catch-all-route, as we return the hock-server instance that
users can work with to add special routes if needed, like
`missing`.

as we return hock itself and the user can add all kinds of routes
that e.g. just match with a special body the feature got impossible
and is also superfluous looking at the current usage pattern
seen in npm tests