### PR TITLE
Upgrade hock to `1.3.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha -R spec"
   },
   "dependencies": {
-    "hock": "~0.2.5",
+    "hock": "~1.3.2",
     "util-extend": "~1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #28.

(Travis CI claims failure, but we're testing on 0.8 and 0.10 where 0.10 passes.) 
